### PR TITLE
Disable desktop-save-mode while profiling

### DIFF
--- a/esup.el
+++ b/esup.el
@@ -108,7 +108,7 @@ Includes execution time, gc time and number of gc pauses."
 
 (defvar esup-esup-path
   (or (and load-in-progress
-	   load-file-name)
+           load-file-name)
       (find-library-name "esup"))
   "Full path to esup.el")
 


### PR DESCRIPTION
I added a line to `esup-batch` that disables desktop-save-mode when profiling. Otherwise the emacs subprocess will pause when exiting and ask the user if they want to save the desktop. 
