### PR TITLE
Remove unused variables

### DIFF
--- a/esup-child.el
+++ b/esup-child.el
@@ -210,8 +210,6 @@ Returns a list of class `esup-result'."
                  (car-safe (read-from-string sexp-string))))
          (line-number (line-number-at-pos start))
          (file-name (buffer-file-name))
-         benchmark
-         esup--load-file-name
          esup--profile-results)
 
     (esup-child-send-log


### PR DESCRIPTION
I got following warnings when byte-compile.

```
esup-child.el:203:1:Warning: Unused lexical variable `esup--load-file-name'
esup-child.el:203:1:Warning: Unused lexical variable `benchmark'
```
