### PR TITLE
Disable debugging when profiling child emacs

### DIFF
--- a/esup-child.el
+++ b/esup-child.el
@@ -138,7 +138,6 @@ a complete result.")
   (setq esup-child-parent-results-process
         (esup-child-init-stream port "RESULTSSTREAM"))
 
-  (toggle-debug-on-error)
   (setq enable-local-variables :safe)
   (prog1
       (esup-child-profile-file init-file 0)

--- a/esup.el
+++ b/esup.el
@@ -359,7 +359,6 @@ The child Emacs send data to this process on
   (let ((process-args `("*esup-child*"
                         "*esup-child*"
                         ,esup-emacs-path
-                        "--debug-init"
                         "-q"
                         "-L" ,esup-load-path
                         "-l" "esup-child"


### PR DESCRIPTION
Thank you for this wonderful package. It helped me diagnose a 20+ second startup time issue. 

`esup` often stops during profiling large init files due to debugging being enabled. These changes turn off debugging during profiling.