### PR TITLE
Set after-init-time to nil when loading init-file

### DIFF
--- a/esup-child.el
+++ b/esup-child.el
@@ -197,7 +197,8 @@ LEVEL is the number of `load's or `require's we've stepped into."
                           (point)))
               (start (progn (forward-sexp -1)
                             (point)))
-              results)
+              results
+              (after-init-time nil))
           (while (> start last-start)
             (setq results (append results
                                   (esup-child-profile-sexp start end level)))


### PR DESCRIPTION
Some packages act differently depending on whether init has finished
or not. This change makes sure that they think init has not finished,
so that the init-file behaves the same during esup as during regular
startup.