### PR TITLE
Silence byte compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
-language: generic
-sudo: no
+language: emacs-lisp
 env:
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
+  # FIXME: Emacs > 25.3 does not work at this time.
+  # Build at Travis CI produces the following error:
+  #
+  #   error while loading shared libraries: libgnutls.so.26:
+  #   cannot open shared object file: No such file or directory
+  #
+  # Thus, this is disable for now.  For more see:
+  # https://travis-ci.org/jschaf/esup/jobs/641742587
+  #
+  # - EVM_EMACS=emacs-git-snapshot-travis
 before_install:
   - source ./scripts/travis-evm-cask.sh
   - evm install $EVM_EMACS --use --skip
-  - cask --debug
+  - emacs --version
+  - cask install --verbose
 script:
   - cask exec ert-runner

--- a/Cask
+++ b/Cask
@@ -4,6 +4,8 @@
 (package-file "esup.el")
 (files "esup-child.el")
 
+(depends-on "cl-lib" "0.5")
+
 (development
  (depends-on "dash")
  (depends-on "ert-runner")

--- a/esup-child.el
+++ b/esup-child.el
@@ -365,7 +365,7 @@ SEXP-STRING appears in FILE-NAME."
 
           ;; Otherwise, use the normal profile results.
           (list
-           (esup-result "esup-result"
+           (esup-result (when (<= emacs-major-version 25) "esup-result")
                         :file file-name
                         :expression-string sexp-string
                         :start-point start-point :end-point end-point
@@ -378,7 +378,7 @@ SEXP-STRING appears in FILE-NAME."
 
 
 (defun esup-child-require-feature-to-filename (feature &optional filename)
-  "Given a require FEATURE, return the corresponding file-name."
+  "Given a require FEATURE, return the corresponding FILENAME."
   (esup-child-send-log
    "converting require to file-name feature='%s' filename='%s'"
    feature filename)
@@ -398,7 +398,7 @@ SEXP-STRING appears in FILE-NAME."
   "Serialize an ESUP-RESULT into a `read'able string.
 We need this because `prin1-to-string' isn't stable between Emacs 25 and 26."
   (concat
-   "(esup-result \"esup-result\" "
+   "(esup-result (when (<= emacs-major-version 25) \"esup-result\") "
    (format ":file %s "
            (prin1-to-string (oref esup-result :file)))
    (format ":start-point %d " (oref esup-result :start-point))

--- a/test/esup-test.el
+++ b/test/esup-test.el
@@ -7,7 +7,10 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl))
+  (if (and (<= emacs-major-version 24)
+           (<= emacs-minor-version 3))
+      (require 'cl)
+    (require 'cl-lib)))
 
 (require 'esup-child)
 (require 'noflet)


### PR DESCRIPTION
Hello,

This patch partially solve warnings described in #68.

First, it aims to fix the following warning at  byte compiling time:
```
esup-child.el: Obsolete name arg "esup-result" to constructor esup-result
```
For more see: https://lists.gnu.org/archive/html/emacs-devel/2018-02/msg00342.html

Also I added missed `cl-lib` to the Cask file and corrected `test/esup-test` to require `cl` if Emacs <= 24.3, otherwise require `cl-lib`. This fixes the following warning:
```
Package cl is deprecated
```

Finally, I fixed the docsstring for `esup-child-require-feature-to-filename` defun.

/cc @jschaf 