### PR TITLE
Fixed byte compiling warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 
 .PHONY: init
 init: Cask
-	@@$(CASK) install
+	@$(CASK) install
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ CASK ?= cask
 EMACSFLAGS ?=
 TESTFLAGS ?= --reporter ert+duration
 
-PKGDIR =
 VERSION = undefined
 
 .DEFAULT_GOAL = build
@@ -31,7 +30,6 @@ ifndef HAVE_CASK
 $(warning "$(CASK) is not available.  Please run make help")
 RUNEMACS = $(EMACSBATCH)
 else
-PKGDIR = $(shell EMACS=$(EMACS) $(CASK) package-directory)
 RUNEMACS = $(CASK) exec $(EMACSBATCH)
 VERSION = $(shell $(CASK) version)
 endif
@@ -39,12 +37,8 @@ endif
 # TODO(serghei): Add byte compile test
 # --eval '(setq byte-compile-error-on-warn t)'
 # See: https://github.com/jschaf/esup/issues/68
-%.elc: %.el $(PKGDIR)
-	$(RUNEMACS) -f batch-byte-compile $<
-
-$(PKGDIR): Cask
-	$(CASK) install
-	@touch $(PKGDIR)
+%.elc: %.el
+	@$(RUNEMACS) -f batch-byte-compile $<
 
 ## Public targets
 
@@ -53,18 +47,20 @@ $(PKGDIR): Cask
 	$(info Esup $(VERSION))
 
 .PHONY: init
-init: $(PKGDIR)
+init: Cask
+	@@$(CASK) install
 
 .PHONY: test
 test:
-	$(CASK) exec ert-runner $(TESTFLAGS)
+	@$(CASK) exec ert-runner $(TESTFLAGS)
 
 .PHONY: build
 build: $(OBJS)
 
 .PHONY: clean
 clean:
-	$(CASK) clean-elc
+	$(info Remove all byte compiled Elisp files...)
+	@$(CASK) clean-elc
 
 .PHONY: help
 help: .title

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ build: $(OBJS)
 .PHONY: clean
 clean:
 	$(info Remove all byte compiled Elisp files...)
-	@$(CASK) clean-elc
+	@$(RM) -f $(OBJS)
 
 .PHONY: help
 help: .title

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,8 @@ RUNEMACS = $(CASK) exec $(EMACSBATCH)
 VERSION = $(shell $(CASK) version)
 endif
 
-# TODO(serghei): Add byte compile test
-# --eval '(setq byte-compile-error-on-warn t)'
-# See: https://github.com/jschaf/esup/issues/68
 %.elc: %.el
-	@$(RUNEMACS) -f batch-byte-compile $<
+	@$(RUNEMACS) --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
 
 ## Public targets
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ older versions of Emacs, but this is NOT guaranteed. Bug reports
 for problems related to using Esup with older versions of
 Emacs will most like not be addressed.
 
+The master of all the material is the Git repository at
+http://github.com/jschaf/esup .
+
+NOTE: The `master` branch will always contain the latest _unstable_ version.
+If you wish to check older versions or formal, tagged release, please switch
+to the relevant [tag][esup tags].
+
 **With MELPA**
 
 First, add the package repository:
@@ -106,3 +113,4 @@ Create a pull request with the normal Github user interface.
 [melpa link]: http://melpa.org/#/esup
 [melpa-s badge]: https://stable.melpa.org/packages/esup-badge.svg
 [melpa-s link]: https://stable.melpa.org/#/esup
+[esup tags]: http://github.com/jschaf/esup/tags

--- a/esup-child.el
+++ b/esup-child.el
@@ -409,15 +409,15 @@ We need this because `prin1-to-string' isn't stable between Emacs 25 and 26."
   (concat
    "(esup-result (when (<= emacs-major-version 25) \"esup-result\") "
    (format ":file %s "
-           (prin1-to-string (oref esup-result :file)))
-   (format ":start-point %d " (oref esup-result :start-point))
-   (format ":line-number %d " (oref esup-result :line-number))
+           (prin1-to-string (slot-value esup-result 'file)))
+   (format ":start-point %d " (slot-value esup-result 'start-point))
+   (format ":line-number %d " (slot-value esup-result 'line-number))
    (format ":expression-string %s "
-           (prin1-to-string (oref esup-result :expression-string)))
-   (format ":end-point %d " (oref esup-result :end-point))
-   (format ":exec-time %f " (oref esup-result :exec-time))
-   (format ":gc-number %d " (oref esup-result :gc-number))
-   (format ":gc-time %f" (oref esup-result :gc-time))
+           (prin1-to-string (slot-value esup-result 'expression-string)))
+   (format ":end-point %d " (slot-value esup-result 'end-point))
+   (format ":exec-time %f " (slot-value esup-result 'exec-time))
+   (format ":gc-number %d " (slot-value esup-result 'gc-number))
+   (format ":gc-time %f" (slot-value esup-result 'gc-time))
    ")"))
 
 (defun esup-child-serialize-results (esup-results)

--- a/esup-child.el
+++ b/esup-child.el
@@ -1,22 +1,31 @@
 ;;; esup-child.el --- lisp file for child Emacs to run. -*- lexical-binding: t -*-
+
 ;; Copyright (C) 2014-2017 Joe Schafer
 
 ;; Author: Joe Schafer <joe@jschaf.com>
-;; Version: 0.6
-;; Keywords:  convenience
+;; Maintainer: Serghei Iakovlev <egrep@protonmail.ch>
+;; Created: 19 May 2013
+;; Version: 0.7.1
+;; URL: http://github.com/jschaf/esup
+;; Keywords: convenience, processes
+;; Package-Requires: ((cl-lib "0.5") (emacs "25"))
 
-;; This program is free software; you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
+;; This file is NOT part of GNU Emacs.
 
-;; This program is distributed in the hope that it will be useful,
+;;;; License
+
+;; This file is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This file is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/esup.el
+++ b/esup.el
@@ -30,27 +30,33 @@
 ;;; Commentary:
 
 ;; `esup' profiles your Emacs startup time by examining all top-level
-;; S-expressions (sexps).  `esup' starts a new Emacs process from Emacs to
-;; profile each SEXP.  After the profiled Emacs is complete, it will exit and
-;; your Emacs will display the results.
+;; S-expressions (sexps).  `esup' starts a new Emacs process from
+;; Emacs to profile each SEXP.  After the profiled Emacs is complete,
+;; it will exit and your Emacs will display the results.
 ;;
-;; `esup' will step into `require' and `load' forms at the top level of a file,
-;; but not if they're enclosed in any other statement.
+;; `esup' will step into `require' and `load' forms at the top level
+;; of a file, but not if they're enclosed in any other statement.
 ;;
 ;; Installation:
 ;;
-;; Place esup.el on your `load-path' by adding this to your
-;; `user-init-file', usually ~/.emacs or ~/.emacs.d/init.el
+;; Place esup.el and esup-child.el on your `load-path' by adding this
+;; to your `user-init-file', usually ~/.emacs or ~/.emacs.d/init.el
 ;;
-;; (add-to-list 'load-path "~/dir/to-esup")
+;;   (add-to-list 'load-path "~/dir/to-esup")
 ;;
 ;; Load the code:
 ;;
-;; (autoload 'esup "esup" "Emacs Start Up Profiler." nil)
+;;   (autoload 'esup "esup" "Emacs Start Up Profiler." nil)
 ;;
 ;; M-x `esup' to profile your Emacs startup and display the results.
 ;;
-;; The most recent code is always at http://github.com/jschaf/esup
+;; The master of all the material is the GitHub repository
+;; (see URL `https://github.com/jschaf/esup').
+;;
+;; Bugs:
+;;
+;; Bug tracking is currently handled using the GitHub issue tracker
+;; (see URL `https://github.com/jschaf/esup/issues').
 
 ;;; Code:
 
@@ -58,6 +64,13 @@
 ;;; Requirements
 
 (require 'eieio)
+(require 'esup-child)
+
+(eval-when-compile
+  (require 'cl-lib))
+
+
+;;; Esup internals
 
 (defvar esup-load-path
   ;; Emacs doesn't visit a file when loading it, meaning
@@ -68,16 +81,8 @@
                           buffer-file-name)))
   "Full directory path to esup.el and esup-child.el.")
 
-;; We need to load esup-child to access `esup-result'.  `esup-child' may not be
-;; on the path, so lets add it here.
-(let ((load-path (append load-path (list esup-load-path))))
-  (require 'esup-child))
-
-(eval-when-compile
-  (require 'cl-lib))
-
 
-;; User variables
+;;; User variables
 
 (defgroup esup nil
   "A major mode for the Emacs Start Up Profiler."

--- a/esup.el
+++ b/esup.el
@@ -3,26 +3,41 @@
 ;; Copyright (C) 2014-2017 Joe Schafer
 
 ;; Author: Joe Schafer <joe@jschaf.com>
-;; Maintainer:  Joe Schafer <joe@jschaf.com>
+;; Maintainer: Serghei Iakovlev <egrep@protonmail.ch>
 ;; Created: 19 May 2013
+;; Version: 0.7.1
 ;; URL: http://github.com/jschaf/esup
-;; Version:  0.7
-;; Package-Requires: ((cl-lib "0.5") (emacs "25"))
 ;; Keywords: convenience, processes
+;; Package-Requires: ((cl-lib "0.5") (emacs "25"))
 
 ;; This file is NOT part of GNU Emacs.
 
-;; This program is free software; you can redistribute it and/or
+;;;; License
+
+;; This file is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
-;; as published by the Free Software Foundation; either version 2
+;; as published by the Free Software Foundation; either version 3
 ;; of the License, or (at your option) any later version.
-;;
-;; This program is distributed in the hope that it will be useful,
+
+;; This file is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
-;;; Installation:
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; `esup' profiles your Emacs startup time by examining all top-level
+;; S-expressions (sexps).  `esup' starts a new Emacs process from Emacs to
+;; profile each SEXP.  After the profiled Emacs is complete, it will exit and
+;; your Emacs will display the results.
+;;
+;; `esup' will step into `require' and `load' forms at the top level of a file,
+;; but not if they're enclosed in any other statement.
+;;
+;; Installation:
 ;;
 ;; Place esup.el on your `load-path' by adding this to your
 ;; `user-init-file', usually ~/.emacs or ~/.emacs.d/init.el
@@ -34,18 +49,13 @@
 ;; (autoload 'esup "esup" "Emacs Start Up Profiler." nil)
 ;;
 ;; M-x `esup' to profile your Emacs startup and display the results.
-
-;;; Commentary:
 ;;
 ;; The most recent code is always at http://github.com/jschaf/esup
-;;
-;; `esup' profiles your Emacs startup time by examining all top-level
-;; S-expressions (sexps).  `esup' starts a new Emacs process from Emacs to
-;; profile each SEXP.  After the profiled Emacs is complete, it will exit and
-;; your Emacs will display the results.
-;;
-;; `esup' will step into `require' and `load' forms at the top level of a file,
-;; but not if they're enclosed in any other statement.
+
+;;; Code:
+
+
+;;; Requirements
 
 (require 'eieio)
 
@@ -63,16 +73,8 @@
 (let ((load-path (append load-path (list esup-load-path))))
   (require 'esup-child))
 
-
-;; On Emacs 24.3 and below, the `with-slots' macro expands to `symbol-macrolet'
-;; instead of `cl-symbol-macrolet'.
 (eval-when-compile
-  (if (and (<= emacs-major-version 24)
-           (<= emacs-minor-version 3))
-      (require 'cl)
-    (require 'cl-lib)))
-
-;;; Code:
+  (require 'cl-lib))
 
 
 ;; User variables
@@ -157,6 +159,7 @@ Includes execution time, gc time and number of gc pauses."
   "A list of error messages from the child Emacs.")
 
 
+
 (defun esup-total-exec-time (results)
   "Calculate the total execution time of RESULTS."
   (cl-loop for result in results


### PR DESCRIPTION
- Fixed module headers to follow conventions;
  See https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)

- Fixed byte compiling warnings;
  Fixes:  https://github.com/jschaf/esup/issues/68

- Replaced all the `oref` with `slot-value` and properly used quotes;
  See: https://lists.gnu.org/archive/html/emacs-devel/2016-02/msg01235.html

- Turn byte compile warning into errors on CI stage

- Update documentation

- Bump version