### PR TITLE
Fix indentation in the esup buffer

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,6 +7,7 @@
 (files "esup-child.el")
 
 (depends-on "cl-lib" "0.5")
+(depends-on "s" "1.2")
 
 (development
  (depends-on "dash")

--- a/esup.el
+++ b/esup.el
@@ -7,7 +7,7 @@
 ;; Version: 0.7.1
 ;; URL: https://github.com/jschaf/esup
 ;; Keywords: convenience, processes
-;; Package-Requires: ((cl-lib "0.5") (emacs "25"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/test/test-esup.el
+++ b/test/test-esup.el
@@ -6,6 +6,7 @@
 ;; Maintainer: Serghei Iakovlev <egrep@protonmail.ch>
 ;; Version: 0.7.1
 ;; URL: https://github.com/jschaf/esup
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -72,6 +73,17 @@
     (with-esup-mock
      '(:load-path ("/fake")
        :files (("/fake/foo-bar.el" . "")))
+
+     (should
+      (esup-results-equal-p
+       '(:gc-time :exec-time)
+       (esup-child-run "/fake/foo-bar.el" -1)
+       (list)))))
+
+  (it "handles whitespace-only file"
+    (with-esup-mock
+     '(:load-path ("/fake")
+       :files (("/fake/foo-bar.el" . "  ")))
 
      (should
       (esup-results-equal-p


### PR DESCRIPTION
Fixes #63 by adding a function to strip common leading whitespace from a multiline string.

This should behave correctly for all styles of indentation _except_ for strings with an inconsistent mixture of tabs and spaces between lines.