### PR TITLE
Remove s lib as dep and replace with built-in or extraction.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Initialize the Project
         run: make init
 
-      - name: Byte Compile BNF Mode
+      - name: Byte Compile Esup
         run: make
 
       - name: Run Unit Tests (+falures)

--- a/Cask
+++ b/Cask
@@ -7,7 +7,6 @@
 (files "esup-child.el")
 
 (depends-on "cl-lib" "0.5")
-(depends-on "s" "1.2")
 
 (development
  (depends-on "dash")

--- a/esup-child.el
+++ b/esup-child.el
@@ -37,6 +37,7 @@
 (require 'benchmark)
 (require 'eieio)
 (require 'seq)
+(require 'subr-x)
 
 ;; We don't use :accesssor for class slots because it cause a
 ;; byte-compiler error even if we use the accessor.  This is fixed in

--- a/esup-child.el
+++ b/esup-child.el
@@ -188,17 +188,23 @@ a complete result.")
     (setq str (replace-match "" t t str)))
   str)
 
+(defun esup-s-pad-left (len padding s)
+  "If S is shorter than LEN, pad it with PADDING on the left."
+  (let ((extra (max 0 (- len (length s)))))
+    (concat (make-string extra (string-to-char padding))
+            s)))
+
 (defun esup-child-unindent (str)
   "Remove common leading whitespace from each line of STR.
 If STR contains only whitespace, return an empty string."
-  (let* ((lines (s-lines str))
-         (non-whitespace-lines (seq-filter (lambda (s) (< 0 (length (s-trim-left s))))
+  (let* ((lines (split-string str "\n"))
+         (non-whitespace-lines (seq-filter (lambda (s) (< 0 (length (string-trim-left s))))
                                            lines))
-         (n-to-trim (apply #'min (mapcar (lambda (s) (- (length s) (length (s-trim-left s))))
+         (n-to-trim (apply #'min (mapcar (lambda (s) (- (length s) (length (string-trim-left s))))
                                          (or non-whitespace-lines [""]))))
-         (result (s-join "\n"
-                         (mapcar (lambda (s) (substring (s-pad-left n-to-trim " " s) n-to-trim))
-                                 lines))))
+         (result (string-join (mapcar (lambda (s) (substring (esup-s-pad-left n-to-trim " " s) n-to-trim))
+                                      lines)
+                              "\n")))
     (if (= 0 (length (esup-child-chomp result))) "" result)))
 
 (defmacro with-esup-child-increasing-depth (&rest body)

--- a/esup-child.el
+++ b/esup-child.el
@@ -197,7 +197,7 @@ a complete result.")
 (defun esup-child-unindent (str)
   "Remove common leading whitespace from each line of STR.
 If STR contains only whitespace, return an empty string."
-  (let* ((lines (split-string str "\n"))
+  (let* ((lines (split-string str "\\(\r\n\\|[\n\r]\\)"))
          (non-whitespace-lines (seq-filter (lambda (s) (< 0 (length (string-trim-left s))))
                                            lines))
          (n-to-trim (apply #'min (mapcar (lambda (s) (- (length s) (length (string-trim-left s))))

--- a/esup-child.el
+++ b/esup-child.el
@@ -7,7 +7,7 @@
 ;; Version: 0.7.1
 ;; URL: https://github.com/jschaf/esup
 ;; Keywords: convenience, processes
-;; Package-Requires: ((cl-lib "0.5") (s "1.2") (emacs "25.1"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -36,7 +36,6 @@
 
 (require 'benchmark)
 (require 'eieio)
-(require 's)
 (require 'seq)
 
 ;; We don't use :accesssor for class slots because it cause a

--- a/esup-child.el
+++ b/esup-child.el
@@ -188,7 +188,7 @@ a complete result.")
     (setq str (replace-match "" t t str)))
   str)
 
-(defun esup-s-pad-left (len padding s)
+(defun esup-child-s-pad-left (len padding s)
   "If S is shorter than LEN, pad it with PADDING on the left."
   (let ((extra (max 0 (- len (length s)))))
     (concat (make-string extra (string-to-char padding))
@@ -202,7 +202,7 @@ If STR contains only whitespace, return an empty string."
                                            lines))
          (n-to-trim (apply #'min (mapcar (lambda (s) (- (length s) (length (string-trim-left s))))
                                          (or non-whitespace-lines [""]))))
-         (result (string-join (mapcar (lambda (s) (substring (esup-s-pad-left n-to-trim " " s) n-to-trim))
+         (result (string-join (mapcar (lambda (s) (substring (esup-child-s-pad-left n-to-trim " " s) n-to-trim))
                                       lines)
                               "\n")))
     (if (= 0 (length (esup-child-chomp result))) "" result)))


### PR DESCRIPTION
I have remove s dependency and replace it with built-in functions. And the `esup-child-s-pad-left` is the only function that is directly extracted from `s` lib.

This should directly fixed #81.