### PR TITLE
Evaluate using lexical-binding if the file is lexically scoped

### DIFF
--- a/esup-child.el
+++ b/esup-child.el
@@ -380,7 +380,7 @@ SEXP-STRING appears in FILE-NAME."
                   ""
                 (car-safe (read-from-string sexp-string))))
         benchmark)
-    (setq benchmark (benchmark-run (eval sexp)))
+    (setq benchmark (benchmark-run (eval sexp lexical-binding)))
     (prog1
         (if esup-child-last-call-intercept-results
             ;; We intercepted the last call with advice on load or


### PR DESCRIPTION
I have code in my init.el that requires lexical scoping, and it could not be evaluated correctly without passing setting `lexical` when calling `eval`.

This patch uses the buffer-local value of `lexical-binding` to invoke `eval` correctly.